### PR TITLE
swap tx/rx pins

### DIFF
--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common-pinctrl.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common-pinctrl.dtsi
@@ -36,15 +36,15 @@
 
 	uart2_default: uart2_default {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 24)>,
-				<NRF_PSEL(UART_RX, 0, 23)>;
+			psels = <NRF_PSEL(UART_TX, 0, 23)>,
+				<NRF_PSEL(UART_RX, 0, 24)>;
 		};
 	};
 
 	uart2_sleep: uart2_sleep {
 		group1 {
-			psels = <NRF_PSEL(UART_TX, 0, 24)>,
-				<NRF_PSEL(UART_RX, 0, 23)>;
+			psels = <NRF_PSEL(UART_TX, 0, 23)>,
+				<NRF_PSEL(UART_RX, 0, 24)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
The Aludel-mini has the tx/rx lines for the click headers switched. There are zero-ohm resistor in place to fix this, but since we already have a number of boards in the field we'll leave the hardware as is and correct in the pinctrl file.