### PR TITLE
change runner order

### DIFF
--- a/boards/arm/aludel_mini_v1_sparkfun9160/board.cmake
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(nrfjprog "--nrf-family=NRF91")
 board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
-include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+board_runner_args(nrfjprog "--nrf-family=NRF91")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
Place the jlink runner as the first in the board.cmake file. This resolves the issue of the board not resetting after being flashed with a J-Link programmer.