### PR TITLE
Disable UART_CONSOLE on Aludel Mini mcuboot config

### DIFF
--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_mcuboot.conf
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_mcuboot.conf
@@ -1,5 +1,7 @@
 # Disable Zephyr console
 CONFIG_CONSOLE=n
+CONFIG_CONSOLE_HANDLER=n
+CONFIG_UART_CONSOLE=n
 
 # Multithreading
 CONFIG_MULTITHREADING=y


### PR DESCRIPTION
This PR fixes the following warning when building for the `aludel_mini_v1_sparkfun9160_ns` board:

```
warning: UART_CONSOLE (defined at drivers/console/Kconfig:43) was assigned the value 'y' but got the
value 'n'. Check these unsatisfied dependencies: CONSOLE (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_UART_CONSOLE and/or look up UART_CONSOLE in
the menuconfig/guiconfig interface. The Application Development Primer, Setting Configuration
Values, and Kconfig - Tips and Best Practices sections of the manual might be helpful too.
```
