### PR TITLE
Silence unique_unit_address_if_enabled warnings for nRF9160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- Suppress `unique_unit_address_if_enabled` warnings for the `aludel_mini_v1_sparkfun9160` board.
 
 ### Changed
 
@@ -17,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `UART_CONSOLE` build warnings for `aludel_mini_v1_sparkfun9160` board
+- Fix `UART_CONSOLE` build warnings for the `aludel_mini_v1_sparkfun9160` board.
 
 ## [1.0.0] - 2023-08-14
 

--- a/boards/arm/aludel_mini_v1_sparkfun9160/pre_dt_board.cmake
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
Silences the following warnings when building for the `aludel_mini_v1_sparkfun9160` board by copying [pre_dt_board.cmake](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/nrf9160dk_nrf9160/pre_dt_board.cmake) from the nRF9160-DK board:

```
Warning (unique_unit_address_if_enabled): /soc/peripheral@40000000/flash-controller@39000: duplicate unit-address (also used in node /soc/peripheral@40000000/kmu@39000)
Warning (unique_unit_address_if_enabled): /soc/peripheral@40000000/clock@5000: duplicate unit-address (also used in node /soc/peripheral@40000000/power@5000)
```

See https://github.com/zephyrproject-rtos/zephyr/issues/29713 for some additional historical context.