### PR TITLE
Enable internal pull-up resistors on Aludel Mini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Disable external NOR flash (`CONFIG_SPI_NOR=n`) on the `aludel_mini_v1_sparkfun9160 board` to fix a conflict with the SPI3 peripheral.
+- Disable external NOR flash (`CONFIG_SPI_NOR=n`) on the `aludel_mini_v1_sparkfun9160` board to fix a conflict with the SPI3 peripheral.
+- Enable internal I2C pull-ups for I2C1 peripheral pins on the `aludel_mini_v1_sparkfun9160` board.
 
 ## [1.0.1] - 2023-09-01
 

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common-pinctrl.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common-pinctrl.dtsi
@@ -53,6 +53,7 @@
 		group1 {
 			psels = <NRF_PSEL(TWIM_SDA, 0, 26)>,
 				<NRF_PSEL(TWIM_SCL, 0, 27)>;
+			bias-pull-up;
 		};
 	};
 


### PR DESCRIPTION
Aludel Mini does not have any onboard I2C pull-up resistors. If you try to use Ostentus (which also doesn't have any onboard pull-up resistors) without a Click board installed that _does_ have pull-up resistors, you'll get an error.

This PR enables internal weak pull-up resistors on the Aludel Mini board so that Ostentus can be used.

**Note:** these weak pull-up resistors are not strong enough for 400 kHz I2C, so make sure that you don't change the default 100 kHz I2C clock frequency (it's `clock-frequency = <I2C_BITRATE_STANDARD>;` by default for nRF9160 chip)