### PR TITLE
Add missing current-speed parameter to uart2 on Aludel Mini board

### DIFF
--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -120,6 +120,7 @@
 };
 
 &uart2 {
+	current-speed = <115200>;
 	pinctrl-0 = <&uart2_default>;
 	pinctrl-1 = <&uart2_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
I ran into this when trying to build the Modbus RD firmware for the Aludel Mini board.