### PR TITLE
Aludel Mini updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add .editorconfig and .clang-format.
+- Add `NRF_PS_EN` to feather connector GPIO nexus for the `aludel_mini_v1_sparkfun9160` board.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add .editorconfig and .clang-format.
 - Add `NRF_PS_EN` to feather connector GPIO nexus for the `aludel_mini_v1_sparkfun9160` board.
 - Add `feather_{serial,i2c,spi}` node labels to `aludel_mini_v1_sparkfun9160` board.
+- Add mikroBUS connector GPIO nexus nodes to `aludel_mini_v1_sparkfun9160` board.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add .editorconfig and .clang-format.
 - Add `NRF_PS_EN` to feather connector GPIO nexus for the `aludel_mini_v1_sparkfun9160` board.
+- Add `feather_{serial,i2c,spi}` node labels to `aludel_mini_v1_sparkfun9160` board.
 
 ### Fixed
 

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -92,6 +92,10 @@
 	};
 };
 
+feather_serial: &uart2 {};
+feather_i2c: &i2c1 {};
+feather_spi: &spi2 {};
+
 &adc {
 	status = "okay";
 };

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -90,11 +90,62 @@
 				<19 0 &gpio0 3 0>,	/* D12 (PWM0) */
 				<20 0 &gpio0 4 0>;	/* D13 (PWM1) */		
 	};
+
+	mikrobus_header_1: mikrobus-connector-1 {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &feather_header 1 0>,	/* AN1 */
+				<1 0 &feather_header 20 0>,	/* RST1 */
+				<2 0 &feather_header 15 0>,	/* CS1 */
+				<3 0 &feather_header 6 0>,	/* SCK */
+				<4 0 &feather_header 8 0>,	/* MISO */
+				<5 0 &feather_header 7 0>,	/* MOSI */
+								/* +3.3V */
+								/* GND */
+				<6 0 &feather_header 3 0>,	/* PWM1 */
+				<7 0 &feather_header 17 0>,	/* INT1 */
+				<8 0 &feather_header 9 0>,	/* RX */
+				<9 0 &feather_header 10 0>,	/* TX */
+				<10 0 &feather_header 13 0>,	/* SCL */
+				<11 0 &feather_header 12 0>;	/* SDA */
+								/* +5V */
+								/* GND */
+	};
+
+	mikrobus_header_2: mikrobus-connector-2 {
+		compatible = "mikro-bus";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map =	<0 0 &feather_header 2 0>,	/* AN2 */
+				<1 0 &feather_header 5 0>,	/* RST2 */
+				<2 0 &feather_header 16 0>,	/* CS2 */
+				<3 0 &feather_header 6 0>,	/* SCK */
+				<4 0 &feather_header 8 0>,	/* MISO */
+				<5 0 &feather_header 7 0>,	/* MOSI */
+								/* +3.3V */
+								/* GND */
+				<6 0 &feather_header 4 0>,	/* PWM2 */
+				<7 0 &feather_header 18 0>,	/* INT2 */
+				<8 0 &feather_header 9 0>,	/* RX */
+				<9 0 &feather_header 10 0>,	/* TX */
+				<10 0 &feather_header 13 0>,	/* SCL */
+				<11 0 &feather_header 12 0>;	/* SDA */
+								/* +5V */
+								/* GND */
+	};
 };
 
 feather_serial: &uart2 {};
 feather_i2c: &i2c1 {};
 feather_spi: &spi2 {};
+
+mikrobus_serial: &uart2 {};
+mikrobus_i2c: &i2c1 {};
+mikrobus_spi: &spi2 {};
+mikrobus_header: &mikrobus_header_1 {};
 
 &adc {
 	status = "okay";

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -68,27 +68,27 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map = <12 0 &gpio0 26 0>,  /* SDA */
-		<13 0 &gpio0 27 0>,  /* SCL */
-		<14 0 &gpio0 29 0>,  /* PWM3 */
-		<15 0 &gpio0 30 0>,  /* PWM3 */
-		<16 0 &gpio0 0 0>,   /* PWM1 */
-		<17 0 &gpio0 1 0>,   /* PWM1 */
-		<18 0 &gpio0 2 0>,   /* PWM1 */
-		<19 0 &gpio0 3 0>,   /* PWM0 */
-		<20 0 &gpio0 4 0>,   /* PWM1 */
-		/* 11 not connected */
-		<10 0 &gpio0 24 0>,  /* TX */
-		<9 0 &gpio0 23 0>,   /* RX */
-		<8 0 &gpio0 22 0>,   /* MISO */
-		<7 0 &gpio0 21 0>,   /* MOSI */
-		<6 0 &gpio0 19 0>,   /* SCK */
-		<5 0 &gpio0 18 0>,   /* SS */
-		<4 0 &gpio0 17 0>,   /* ADC4 = AIN6 */
-		<3 0 &gpio0 16 0>,   /* ADC3 = AIN5 */
-		<2 0 &gpio0 15 0>,   /* ADC2 = AIN4 */
-		<1 0 &gpio0 14 0>,   /* ADC1 = AIN2 */
-		<0 0 &gpio0 13 0>;   /* ADC0 = AIN1 */
+		gpio-map =	<12 0 &gpio0 26 0>,	/* SDA */
+				<13 0 &gpio0 27 0>,	/* SCL */
+				<14 0 &gpio0 29 0>,	/* PWM3 */
+				<15 0 &gpio0 30 0>,	/* PWM3 */
+				<16 0 &gpio0 0 0>,	/* PWM1 */
+				<17 0 &gpio0 1 0>,	/* PWM1 */
+				<18 0 &gpio0 2 0>,	/* PWM1 */
+				<19 0 &gpio0 3 0>,	/* PWM0 */
+				<20 0 &gpio0 4 0>,	/* PWM1 */
+				/* 11 not connected */
+				<10 0 &gpio0 24 0>,	/* TX */
+				<9 0 &gpio0 23 0>,	/* RX */
+				<8 0 &gpio0 22 0>,	/* MISO */
+				<7 0 &gpio0 21 0>,	/* MOSI */
+				<6 0 &gpio0 19 0>,	/* SCK */
+				<5 0 &gpio0 18 0>,	/* SS */
+				<4 0 &gpio0 17 0>,	/* ADC4 = AIN6 */
+				<3 0 &gpio0 16 0>,	/* ADC3 = AIN5 */
+				<2 0 &gpio0 15 0>,	/* ADC2 = AIN4 */
+				<1 0 &gpio0 14 0>,	/* ADC1 = AIN2 */
+				<0 0 &gpio0 13 0>;	/* ADC0 = AIN1 */
 	};
 };
 

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -77,7 +77,7 @@
 				<18 0 &gpio0 2 0>,	/* PWM1 */
 				<19 0 &gpio0 3 0>,	/* PWM0 */
 				<20 0 &gpio0 4 0>,	/* PWM1 */
-				/* 11 not connected */
+				<11 0 &gpio0 31 0>,	/* NRF_PS_EN */
 				<10 0 &gpio0 24 0>,	/* TX */
 				<9 0 &gpio0 23 0>,	/* RX */
 				<8 0 &gpio0 22 0>,	/* MISO */

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -68,27 +68,27 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<0 0 &gpio0 13 0>,	/* ADC0 = AIN1 */
-				<1 0 &gpio0 14 0>,	/* ADC1 = AIN2 */
-				<2 0 &gpio0 15 0>,	/* ADC2 = AIN4 */
-				<3 0 &gpio0 16 0>,	/* ADC3 = AIN5 */
-				<4 0 &gpio0 17 0>,	/* ADC4 = AIN6 */
-				<5 0 &gpio0 18 0>,	/* SS */
+		gpio-map =	<0 0 &gpio0 13 0>,	/* A0 (ADC0 = AIN1) */
+				<1 0 &gpio0 14 0>,	/* A1 (ADC1 = AIN2) */
+				<2 0 &gpio0 15 0>,	/* A2 (ADC2 = AIN4) */
+				<3 0 &gpio0 16 0>,	/* A3 (ADC3 = AIN5) */
+				<4 0 &gpio0 17 0>,	/* A4 (ADC4 = AIN6) */
+				<5 0 &gpio0 18 0>,	/* A5 (CS) */
 				<6 0 &gpio0 19 0>,	/* SCK */
 				<7 0 &gpio0 21 0>,	/* MOSI */
 				<8 0 &gpio0 22 0>,	/* MISO */
 				<9 0 &gpio0 23 0>,	/* RX */
 				<10 0 &gpio0 24 0>,	/* TX */
-				<11 0 &gpio0 31 0>,	/* NRF_PS_EN */
+				<11 0 &gpio0 31 0>,	/* D4 (NRF_PS_EN) */
 				<12 0 &gpio0 26 0>,	/* SDA */
 				<13 0 &gpio0 27 0>,	/* SCL */
-				<14 0 &gpio0 29 0>,	/* PWM3 */
-				<15 0 &gpio0 30 0>,	/* PWM3 */
-				<16 0 &gpio0 0 0>,	/* PWM1 */
-				<17 0 &gpio0 1 0>,	/* PWM1 */
-				<18 0 &gpio0 2 0>,	/* PWM1 */
-				<19 0 &gpio0 3 0>,	/* PWM0 */
-				<20 0 &gpio0 4 0>;	/* PWM1 */		
+				<14 0 &gpio0 29 0>,	/* D5 (PWM3) */
+				<15 0 &gpio0 30 0>,	/* D6 (PWM3) */
+				<16 0 &gpio0 0 0>,	/* D9 (PWM1) */
+				<17 0 &gpio0 1 0>,	/* D10 (PWM1) */
+				<18 0 &gpio0 2 0>,	/* D11 (PWM1) */
+				<19 0 &gpio0 3 0>,	/* D12 (PWM0) */
+				<20 0 &gpio0 4 0>;	/* D13 (PWM1) */		
 	};
 };
 

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -68,7 +68,19 @@
 		#gpio-cells = <2>;
 		gpio-map-mask = <0xffffffff 0xffffffc0>;
 		gpio-map-pass-thru = <0 0x3f>;
-		gpio-map =	<12 0 &gpio0 26 0>,	/* SDA */
+		gpio-map =	<0 0 &gpio0 13 0>,	/* ADC0 = AIN1 */
+				<1 0 &gpio0 14 0>,	/* ADC1 = AIN2 */
+				<2 0 &gpio0 15 0>,	/* ADC2 = AIN4 */
+				<3 0 &gpio0 16 0>,	/* ADC3 = AIN5 */
+				<4 0 &gpio0 17 0>,	/* ADC4 = AIN6 */
+				<5 0 &gpio0 18 0>,	/* SS */
+				<6 0 &gpio0 19 0>,	/* SCK */
+				<7 0 &gpio0 21 0>,	/* MOSI */
+				<8 0 &gpio0 22 0>,	/* MISO */
+				<9 0 &gpio0 23 0>,	/* RX */
+				<10 0 &gpio0 24 0>,	/* TX */
+				<11 0 &gpio0 31 0>,	/* NRF_PS_EN */
+				<12 0 &gpio0 26 0>,	/* SDA */
 				<13 0 &gpio0 27 0>,	/* SCL */
 				<14 0 &gpio0 29 0>,	/* PWM3 */
 				<15 0 &gpio0 30 0>,	/* PWM3 */
@@ -76,19 +88,7 @@
 				<17 0 &gpio0 1 0>,	/* PWM1 */
 				<18 0 &gpio0 2 0>,	/* PWM1 */
 				<19 0 &gpio0 3 0>,	/* PWM0 */
-				<20 0 &gpio0 4 0>,	/* PWM1 */
-				<11 0 &gpio0 31 0>,	/* NRF_PS_EN */
-				<10 0 &gpio0 24 0>,	/* TX */
-				<9 0 &gpio0 23 0>,	/* RX */
-				<8 0 &gpio0 22 0>,	/* MISO */
-				<7 0 &gpio0 21 0>,	/* MOSI */
-				<6 0 &gpio0 19 0>,	/* SCK */
-				<5 0 &gpio0 18 0>,	/* SS */
-				<4 0 &gpio0 17 0>,	/* ADC4 = AIN6 */
-				<3 0 &gpio0 16 0>,	/* ADC3 = AIN5 */
-				<2 0 &gpio0 15 0>,	/* ADC2 = AIN4 */
-				<1 0 &gpio0 14 0>,	/* ADC1 = AIN2 */
-				<0 0 &gpio0 13 0>;	/* ADC0 = AIN1 */
+				<20 0 &gpio0 4 0>;	/* PWM1 */		
 	};
 };
 

--- a/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
+++ b/boards/arm/aludel_mini_v1_sparkfun9160/aludel_mini_v1_sparkfun9160_common.dtsi
@@ -211,8 +211,7 @@ mikrobus_header: &mikrobus_header_1 {};
 &spi2 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
-	cs-gpios = <&gpio0 30 GPIO_ACTIVE_LOW>,
-				<&gpio0 0 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio0 30 GPIO_ACTIVE_LOW>, <&gpio0 0 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";


### PR DESCRIPTION
- Add `NRF_PS_EN` to feather connector GPIO nexus for the `aludel_mini_v1_sparkfun9160` board.
- Add `feather_{serial,i2c,spi}` node labels to `aludel_mini_v1_sparkfun9160` board.
- Add mikroBUS connector GPIO nexus nodes to `aludel_mini_v1_sparkfun9160` board
  - Note: this provides the exact same mikroBUS interface as the [Arduino Uno Click shield](https://docs.zephyrproject.org/latest/boards/shields/arduino_uno_click/doc/index.html) built into the Zephyr tree so it works with some of the sample apps.

That last one gives us the ability to write more portable DT code by referring to abstract GPIO on the microBUS header, rather than specific GPIO on the MCU, e.g.

```
/ {
	zephyr,user {
		rs485-8-click-en-gpios = <&mikrobus_header_1 1 GPIO_ACTIVE_HIGH>;
	};
};
```