### PR TITLE
Add nrf9160dk_nrf9160 overlays for arduino_uno_click shield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `NRF_PS_EN` to feather connector GPIO nexus for the `aludel_mini_v1_sparkfun9160` board.
 - Add `feather_{serial,i2c,spi}` node labels to `aludel_mini_v1_sparkfun9160` board.
 - Add mikroBUS connector GPIO nexus nodes to `aludel_mini_v1_sparkfun9160` board.
+- Add `nrf9160dk_nrf9160` overlays for `arduino_uno_click` shield.
 
 ### Fixed
 

--- a/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160.overlay
+++ b/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9160dk_nrf9160_common.dtsi"

--- a/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_common.dtsi
+++ b/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_common.dtsi
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	/*
+	 * The original Arduino Uno provides the same SCL/SDA on two sets of
+	 * pins, but the nRF9160 DK maps these pins to two different pairs of
+	 * GPIO. When using the Arduino Uno Click Shield board with the nRF9160
+	 * DK, the P0.18/P0.19 pair must be used.
+	 */
+	i2c2_default: i2c2_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 18)>,
+				<NRF_PSEL(TWIM_SCL, 0, 19)>;
+		};
+	};
+
+	i2c2_sleep: i2c2_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 0, 18)>,
+				<NRF_PSEL(TWIM_SCL, 0, 19)>;
+			low-power-enable;
+		};
+	};
+
+	/*
+	 * The default pin group for the nRF9160 DK includes RTS/CTS HW flow
+	 * control, but the Arduino Uno Click Shield board does not connect
+	 * these pins (only TX/RX are connected on the shield). This keeps RX/TX
+	 * on the same pins, but just removes RTS/CTS from the pin groups.
+	 */
+	uart1_default: uart1_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>;
+		};
+	};
+
+	uart1_sleep: uart1_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 1)>,
+				<NRF_PSEL(UART_RX, 0, 0)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/boards/shields/arduino_uno_click/boards/nrf9160dk_nrf9160_ns.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2024 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9160dk_nrf9160_common.dtsi"


### PR DESCRIPTION
This adds `nrf9160dk_nrf9160` board-specific overlays for the `arduino_uno_click` shield (needed by https://github.com/golioth/golioth-zephyr-boards/pull/10)