### PR TITLE
Fix elixir sysbuild

### DIFF
--- a/boards/golioth/aludel_elixir/aludel_elixir_common_B.dtsi
+++ b/boards/golioth/aludel_elixir/aludel_elixir_common_B.dtsi
@@ -79,7 +79,7 @@
 
 	w25q32jv: w25q32jv@2 {
 		compatible = "jedec,spi-nor";
-		status = "okay";
+		status = "disabled";
 		reg = <2>;
 		spi-max-frequency = <40000000>;
 		wp-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;

--- a/boards/golioth/aludel_elixir/aludel_elixir_defconfig
+++ b/boards/golioth/aludel_elixir/aludel_elixir_defconfig
@@ -20,6 +20,3 @@ CONFIG_UART_CONSOLE=y
 
 # Enable pin controller drivers
 CONFIG_PINCTRL=y
-
-# Enable power regulator control
-#CONFIG_REGULATOR=y


### PR DESCRIPTION
Disable the external flash by default to avoid linking issues when building mcuboot with sysbuild.